### PR TITLE
fix: deployment on appoint.gawron.cloud

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -64,7 +64,7 @@ router.use("/users/", userRouter);
 router.get("/ping", (req, res) => {
   res.status(200).send("OK")
 })
-app.use("/meeting/api/v1", router);
+app.use("/api/v1", router);
 
 const PORT = process.env.PORT || 5000;
 

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -26,20 +26,3 @@ spec:
               number: 5000
         path: /api
         pathType: Prefix
-  - host: hopper.fh-swf.de
-    http:
-      paths:
-      - backend:
-          service:
-            name: client
-            port:
-              number: 80
-        path: /meeting
-        pathType: Prefix
-      - backend:
-          service:
-            name: bookme
-            port:
-              number: 5000
-        path: /meeting/api
-        pathType: Prefix


### PR DESCRIPTION
- remove `/meeting` prefix from api route